### PR TITLE
Switched appengine_config to use site.addsitedir()

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -3,4 +3,4 @@ import site
 import os.path
 # add `lib` subdirectory as a site packages directory, so our `main` module can load
 # third-party libraries.
-sys.addsitedir(os.path.join(os.path.dirname(__file__), 'lib'))
+site.addsitedir(os.path.join(os.path.dirname(__file__), 'lib'))


### PR DESCRIPTION
Replacing sys.path.insert() with site.addsitedir() makes it possible to import namespace package dependencies. Closes Issue #8.
