### PR TITLE
Update app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -3,11 +3,6 @@
 # https://developers.google.com/appengine/docs/python/config/appconfig
 # for details.
 
-# TODO: Enter your application id below. If you have signed up
-# using cloud.google.com/console use the "project id" for your application
-# id.
-application: your-application-id-here
-version: 1
 runtime: python27
 api_version: 1
 threadsafe: yes


### PR DESCRIPTION
`application` ID and `version` are now deprecated and should be removed.

`gcloud preview app deploy` warns for the first, and fails for the second unless `--version 1` is specified.